### PR TITLE
unit-testing-debug

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,23 +1,21 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-      {
-        "name": "Debug CRA Tests",
-        "type": "node",
-        "request": "launch",
-        "program": "${workspaceRoot}/node_modules/.bin/jest",      
-        "args": [
-          "--runInBand"
-        ],
-        "cwd": "${workspaceRoot}",
-        "protocol": "inspector",
-        "console": "integratedTerminal",
-        "internalConsoleOptions": "neverOpen",
-        "outFiles": ["${workspaceRoot}/build/**/*"],
-        "sourceMaps": true,
-        "windows": {
-          "program": "${workspaceRoot}/node_modules/jest/bin/jest", 
-        }
-      }
-    ]
-  }
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Unit Tests",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/react-scripts",      
+      "args": [
+        "test",
+        "--runInBand",
+        "--no-cache",
+        "--env=jsdom"
+      ],
+      "cwd": "${workspaceRoot}",
+      "protocol": "inspector",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/src/redux/ducks/monsterColours.js
+++ b/src/redux/ducks/monsterColours.js
@@ -1,7 +1,6 @@
 import { takeLatest, call, put, select } from 'redux-saga/effects';
-import { setMonstersDominantColours } from './monsters'
-import * as Vibrant from 'node-vibrant'
-import axios from "axios/index";
+import { setMonstersDominantColours } from './monsters';
+import * as Vibrant from 'node-vibrant';
 
 // Actions
 const PROCESS = 'MONSTER_COLOURS_PROCESS';
@@ -30,12 +29,12 @@ export default function monsterColoursReducer(state = initialState, action) {
 }
 
 // Action Creators
-export function processMonsterColours(url) {
+export const processMonsterColours = (url) => {
     return {
         type: PROCESS,
         url: url
     };
-}
+};
 
 // Saga Watchers
 export function* watcherProcessMonsterColours() {
@@ -57,7 +56,7 @@ function* workerProcessMonsterColours({url: url}) {
 }
 
 // Helper utilities
-export function getDominantColours(url) {
+export const getDominantColours = (url) => {
     return Vibrant.from(url).getPalette()
         .then(response => {
             const keys = Object.keys(response);
@@ -68,11 +67,11 @@ export function getDominantColours(url) {
 
             return keys.reduce(addPalette, {});
         })
-}
+};
 
-export function calculateCurrentIndex(currentIndex, colours) {
+export const calculateCurrentIndex = (currentIndex, colours) => {
     const colourCount = colours.length;
     console.log('colour count:' + colourCount);
     console.log('colours:' + colours);
     return currentIndex +1;
-}
+};


### PR DESCRIPTION
* Committed vscode launch.json with vanilla config from create-react-app docs.
* Updated function exports to const arrow functions.

This gets the unit tests we were looking at working with debugging. Probably would work in WebStorm too since we saw the same problem there.

The default exported function is still not debuggable. I think this is more of a clue to the underlying problem than an actual solution.